### PR TITLE
Reusable steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ An example of a user story:
 ```gherkin
 Scenario: Refunded items should be returned to stock
   Given that a customer previously bought a black sweater from me
-  And I have three black sweaters in stock.
+  And I have three black sweaters in stock
   When they return the black sweater for a refund
-  Then I should have four black sweaters in stock.
+  Then I should have four black sweaters in stock
 ```
 
 An example of a specification:
@@ -154,7 +154,7 @@ Given(/^that a customer previously bought a black sweater from me$/, async funct
   await this.setPageObjectThenCheckUrl('confirmation');
 });
 
-Given(/^I have three black sweaters in stock.$/, async function() {
+Given(/^I have three black sweaters in stock$/, async function() {
   await this.goToPage('black sweaters');
   await this.setSelectValueByOptionText('amount of items in stock', '3 in stock');
 });
@@ -168,7 +168,7 @@ When(/^they return the black sweater for a refund$/, async function() {
   await this.setPageObjectThenCheckUrl('item returned confirmation');
 });
 
-Then(/^I should have four black sweaters in stock.$/, async function() {
+Then(/^I should have four black sweaters in stock$/, async function() {
   await this.goToPage('black sweaters');
   await this.setSelectValueByOptionText('amount of items in stock', '4 in stock');
 });

--- a/courgette-conf.js
+++ b/courgette-conf.js
@@ -13,6 +13,7 @@ exports.pomConfig = {
   timeoutInSeconds: process.env.courgetteTimeout || 10,
   pagesPath: path.resolve(specsPath, 'pages'),
   componentsPath: path.resolve(specsPath, 'components'),
+  stepsPath: path.resolve(specsPath, 'stepDefinitions'),
   baseUrl: 'http://localhost:3000',
 };
 
@@ -62,6 +63,7 @@ const protractorConfig = {
       `${courgettePath}/hooks/attachScenarioNameBefore.js`,
       `${courgettePath}/hooks/attachScreenshotAfter.js`,
       `${courgettePath}/hooks/deleteAllCookies.js`,
+      `${courgettePath}/hooks/loadSteps.js`,
       `${courgettePath}/hooks/pageObjectModelBefore.js`,
       `${courgettePath}/hooks/addMethodsBefore.js`,
       `${courgettePath}/hooks/setDefaultTimeout.js`,

--- a/sample-courgette-conf-for-test.js
+++ b/sample-courgette-conf-for-test.js
@@ -11,7 +11,7 @@ exports.pomConfig = {
   pagesPath: path.resolve(specsPath, 'pages'),
   componentsPath: path.resolve(specsPath, 'components'),
   stepsPath: path.resolve(specsPath, 'stepDefinitions'),
-  baseUrl: 'https://www.google.co.uk',
+  baseUrl: 'https://www.google.com',
 };
 
 exports.cucumberHtmlReporterConfig = {};

--- a/sample-courgette-conf-for-test.js
+++ b/sample-courgette-conf-for-test.js
@@ -10,7 +10,8 @@ exports.pomConfig = {
   timeoutInSeconds: process.env.courgetteTimeout || 10,
   pagesPath: path.resolve(specsPath, 'pages'),
   componentsPath: path.resolve(specsPath, 'components'),
-  baseUrl: 'https://www.google.com',
+  stepsPath: path.resolve(specsPath, 'stepDefinitions'),
+  baseUrl: 'https://www.google.co.uk',
 };
 
 exports.cucumberHtmlReporterConfig = {};
@@ -62,6 +63,7 @@ const protractorConfig = {
       `${courgettePath}/hooks/pageObjectModelBefore.js`,
       `${courgettePath}/hooks/addMethodsBefore.js`,
       `${courgettePath}/hooks/setDefaultTimeout.js`,
+      `${courgettePath}/hooks/loadSteps.js`,
       `${courgettePath}/stepDefinitions/*.js`,
       `${specsPath}/stepDefinitions/*.js`,
       // `${specsPath}/helpers/hooks.js`,

--- a/testsToValidateStepDefinitions/features/po-not-required.feature
+++ b/testsToValidateStepDefinitions/features/po-not-required.feature
@@ -18,6 +18,11 @@ Feature: Testing steps where page object isn't required
     Given I am on the homepage page and I click the link
     Then I do some assertions
 
+  @no-po-reusable-steps-with-params
+  Scenario: Testing reusable steps with params
+    Given I am on the page with url 'http://localhost:3000' and I click 'Go to other page by react router'
+    Then I do some assertions
+
   @no-po-click-nth
   Scenario: Go to page and click element
     Given I am on the page with url 'http://localhost:3000'

--- a/testsToValidateStepDefinitions/features/po-not-required.feature
+++ b/testsToValidateStepDefinitions/features/po-not-required.feature
@@ -13,6 +13,11 @@ Feature: Testing steps where page object isn't required
     And I expect the url to not be 'http://localhost:3000/foo'
     And take a screenshot
 
+  @no-po-reusable-steps
+  Scenario: Testing reusable steps
+    Given I am on the homepage page and I click the link
+    Then I do some assertions
+
   @no-po-click-nth
   Scenario: Go to page and click element
     Given I am on the page with url 'http://localhost:3000'

--- a/testsToValidateStepDefinitions/stepDefinitions/reusable.steps
+++ b/testsToValidateStepDefinitions/stepDefinitions/reusable.steps
@@ -1,0 +1,10 @@
+Steps: Some reusable steps
+
+  Step: I am on the homepage page and I click the link
+    Given I am on the page with url 'http://localhost:3000'
+    When I click the element with the text 'Go to other page by react router'
+
+  Step: I do some assertions
+    Then I expect the url to be 'http://localhost:3000/other-page'
+    And I expect the url to not be 'http://localhost:3000/foo'
+    And take a screenshot

--- a/testsToValidateStepDefinitions/stepDefinitions/reusable.steps
+++ b/testsToValidateStepDefinitions/stepDefinitions/reusable.steps
@@ -8,3 +8,7 @@ Steps: Some reusable steps
     Then I expect the url to be 'http://localhost:3000/other-page'
     And I expect the url to not be 'http://localhost:3000/foo'
     And take a screenshot
+
+  Step: I am on the page with url '{{PAGE}}' and I click '{{LINK}}'
+    Given I am on the page with url '{{PAGE}}'
+    When I click the element with the text '{{LINK}}'

--- a/uiTestHelpers/hooks/loadSteps.js
+++ b/uiTestHelpers/hooks/loadSteps.js
@@ -39,7 +39,7 @@ stepsFiles.forEach((stepsFile) => {
       let matchCounter = 0;
       const parameterisedStepRegexStr = stepRegexStr.replace(/\{\{(.*?)\}\}/g, (match) => {
         replacements[match] = matchCounter;
-        matchCounter++;
+        matchCounter += 1;
         // replacements.push(match);
         return "([^']*)?";
       });
@@ -58,10 +58,7 @@ stepsFiles.forEach((stepsFile) => {
 
               args = args.map((arg) => {
                 if (typeof arg === 'string') {
-                  let replaceIndex = 0;
-                  return arg.replace(/\{\{(.*?)\}\}/g, (match) => {
-                    return stepDefArgs[replacements[match]];
-                  });
+                  return arg.replace(/\{\{(.*?)\}\}/g, (match) => stepDefArgs[replacements[match]]);
                 }
 
                 return arg;
@@ -102,7 +99,7 @@ stepsFiles.forEach((stepsFile) => {
               }).catch((e) => {
                 console.log(`            ${substeps[i].step} ---> FAILED`.red);
                 console.error(e);
-              })
+              });
             } else {
               console.log(`            ${substeps[i].step} ---> FAILED`.red);
               console.log(`NO STEP FOUND:     ${substeps[i].step}`);
@@ -114,24 +111,26 @@ stepsFiles.forEach((stepsFile) => {
             return Promise.reject(new Error(e));
           }
         }
-      };
-
-      let theFunc =  function() { return theStepDef.call(this); };
-      if (matchCounter === 1) {
-        theFunc =  function(a1) { return theStepDef.call(this, ...arguments); };
-      } else if (matchCounter === 2) {
-        theFunc =  function(a1, a2) { return theStepDef.call(this, ...arguments); };
-      } else if (matchCounter === 3) {
-        theFunc =  function(a1, a2, a3) { return theStepDef.call(this, ...arguments); };
-      } else if (matchCounter === 4) {
-        theFunc =  function(a1, a2, a3, a4) { return theStepDef.call(this, ...arguments); };
-      } else if (matchCounter === 5) {
-        theFunc =  function(a1, a2, a3, a4, a5) { return theStepDef.call(this, ...arguments); };
-      } else if (matchCounter === 6) {
-        theFunc =  function(a1, a2, a3, a4, a5, a6) { return theStepDef.call(this, ...arguments); };
-      } else if (matchCounter === 7) {
-        theFunc =  function(a1, a2, a3, a4, a5, a6, a7) { return theStepDef.call(this, ...arguments); };
       }
+
+      /* eslint-disable */
+      let theFunc = function () { return theStepDef.call(this); };
+      if (matchCounter === 1) {
+        theFunc = function (a1) { return theStepDef.call(this, ...arguments); };
+      } else if (matchCounter === 2) {
+        theFunc = function (a1, a2) { return theStepDef.call(this, ...arguments); };
+      } else if (matchCounter === 3) {
+        theFunc = function (a1, a2, a3) { return theStepDef.call(this, ...arguments); };
+      } else if (matchCounter === 4) {
+        theFunc = function (a1, a2, a3, a4) { return theStepDef.call(this, ...arguments); };
+      } else if (matchCounter === 5) {
+        theFunc = function (a1, a2, a3, a4, a5) { return theStepDef.call(this, ...arguments); };
+      } else if (matchCounter === 6) {
+        theFunc = function (a1, a2, a3, a4, a5, a6) { return theStepDef.call(this, ...arguments); };
+      } else if (matchCounter === 7) {
+        theFunc = function (a1, a2, a3, a4, a5, a6, a7) { return theStepDef.call(this, ...arguments); };
+      }
+      /* eslint-enable */
       defineStep(new RegExp(parameterisedStepRegexStr), theFunc);
     });
   }

--- a/uiTestHelpers/hooks/loadSteps.js
+++ b/uiTestHelpers/hooks/loadSteps.js
@@ -1,0 +1,55 @@
+const path = require('path');
+const yaml = require('yaml-page-objects').default;
+const fs = require('fs');
+const givenSteps = require('../stepDefinitions/commonGivenSteps');
+const whenSteps = require('../stepDefinitions/commonWhenSteps');
+const thenSteps = require('../stepDefinitions/commonThenSteps');
+const commonSteps = [].concat(givenSteps, whenSteps, thenSteps);
+
+// const createPage = require('../../uiTestHelpers/createPage');
+// const createComponent = require('../../uiTestHelpers/createComponent');
+
+const { defineStep } = require(path.join(process.cwd(), 'node_modules/cucumber'));
+const { pomConfig } = require(path.join(process.cwd(), process.env.confFile || 'courgette-conf.js'));
+
+let stepsObj = {};
+let currentStep;
+
+const stepsFiles = fs.readdirSync(pomConfig.stepsPath);
+stepsFiles.forEach((stepsFile) => {
+  if (stepsFile.endsWith('.steps')) {
+    const steps = fs.readFileSync(path.join(pomConfig.stepsPath, stepsFile), 'utf8')
+      .split('\n') // todo: check for windows CRLF
+      .map((step) => step.trim());
+
+    steps.forEach((step) => {
+      if (step.toLowerCase().startsWith('step:')) {
+        currentStep = step.replace(/^Step:( )*/i, '').trim();
+
+        stepsObj[currentStep] = [];
+      } else if (stepsObj[currentStep] && step) {
+        const stepCleaned = step.replace(/^(Given|When|Then|And|But)/i, '').trim();
+        stepsObj[currentStep].push(stepCleaned);
+      }
+    });
+    Object.keys(stepsObj).forEach((stepRegexStr) => { // loop each Step:
+        defineStep(new RegExp(stepRegexStr), async function() {
+          await Promise.all(stepsObj[stepRegexStr].map((substep) => {
+            const correspondingCommonStep = commonSteps.find((commonStep) => {
+              return commonStep.regex && commonStep.regex.test(substep);
+              // console.log(commonStep.regex && commonStep.regex.test(substep), substep, commonStep.regex);
+            });
+
+            if (correspondingCommonStep) {
+              console.log(correspondingCommonStep);
+              const args = substep.match(correspondingCommonStep.regex);
+              args.shift();
+              console.log(args, args.length, 'matches');
+              return require(`../stepDefinitions/${correspondingCommonStep.path}`)(...args);// todo: path on windows
+            }
+          }));
+        });
+      // });
+    });
+  }
+});

--- a/uiTestHelpers/hooks/loadSteps.js
+++ b/uiTestHelpers/hooks/loadSteps.js
@@ -29,27 +29,29 @@ stepsFiles.forEach((stepsFile) => {
         stepsObj[currentStep] = [];
       } else if (stepsObj[currentStep] && step) {
         const stepCleaned = step.replace(/^(Given|When|Then|And|But)/i, '').trim();
-        stepsObj[currentStep].push(stepCleaned);
+        stepsObj[currentStep].push({ stepCleaned, step: step.trim() });
       }
     });
     Object.keys(stepsObj).forEach((stepRegexStr) => { // loop each Step:
-        defineStep(new RegExp(stepRegexStr), async function() {
-          await Promise.all(stepsObj[stepRegexStr].map((substep) => {
-            const correspondingCommonStep = commonSteps.find((commonStep) => {
-              return commonStep.regex && commonStep.regex.test(substep);
-              // console.log(commonStep.regex && commonStep.regex.test(substep), substep, commonStep.regex);
-            });
+      defineStep(new RegExp(stepRegexStr), async function() {
+        const substeps = stepsObj[stepRegexStr];
+        for (var i = 0; i < substeps.length; i++) {
+          const substepCleaned = substeps[i].stepCleaned;
+          const correspondingCommonStep = commonSteps.find((commonStep) => {
+            return commonStep.regex && commonStep.regex.test(substepCleaned);
+          });
 
-            if (correspondingCommonStep) {
-              console.log(correspondingCommonStep);
-              const args = substep.match(correspondingCommonStep.regex);
-              args.shift();
-              console.log(args, args.length, 'matches');
-              return require(`../stepDefinitions/${correspondingCommonStep.path}`)(...args);// todo: path on windows
-            }
-          }));
-        });
-      // });
+          if (correspondingCommonStep) {
+            console.log('            ', substeps[i].step);
+            const args = substepCleaned.match(correspondingCommonStep.regex);
+            args.shift();
+
+            await require(`../stepDefinitions/${correspondingCommonStep.path}`)(...args);// todo: path on windows
+          } else {
+            console.error('No step found for ', substepCleaned);
+          }
+        }
+      });
     });
   }
 });

--- a/uiTestHelpers/hooks/loadSteps.js
+++ b/uiTestHelpers/hooks/loadSteps.js
@@ -5,6 +5,7 @@ const givenSteps = require('../stepDefinitions/commonGivenSteps');
 const whenSteps = require('../stepDefinitions/commonWhenSteps');
 const thenSteps = require('../stepDefinitions/commonThenSteps');
 const commonSteps = [].concat(givenSteps, whenSteps, thenSteps);
+require('colors');
 
 // const createPage = require('../../uiTestHelpers/createPage');
 // const createComponent = require('../../uiTestHelpers/createComponent');
@@ -38,15 +39,16 @@ stepsFiles.forEach((stepsFile) => {
     Object.keys(stepsObj).forEach((stepRegexStr) => { // loop each Step:
       defineStep(new RegExp(stepRegexStr), async function() {
         const substeps = stepsObj[stepRegexStr];
+        console.log(`\nStep: ${stepRegexStr}`);
         for (var i = 0; i < substeps.length; i++) {
           const substepCleaned = substeps[i].stepCleaned;
           const correspondingCommonStep = commonSteps.find((commonStep) => {
             return commonStep.regex && commonStep.regex.test(substepCleaned);
           });
 
+
           try {
             if (correspondingCommonStep) {
-              console.log('            ', substeps[i].step);
               const args = substepCleaned.match(correspondingCommonStep.regex);
               args.shift();
               const argsToPass = args.length;
@@ -76,11 +78,14 @@ stepsFiles.forEach((stepsFile) => {
                 // console.log('callbackPromise', callbackPromise);
                 await callbackPromise();
               }
+              console.log(`            ${substeps[i].step} ---> PASSED`.green);
             } else {
               return Promise.reject(`No step found for:     ${substeps[i].step}`);
             }
           } catch (e) {
-            console.log(e);
+            console.log(`            ${substeps[i].step} ---> FAILED`.red);
+            console.error(e);
+            return Promise.reject(e);
           }
         }
       });

--- a/uiTestHelpers/hooks/loadSteps.js
+++ b/uiTestHelpers/hooks/loadSteps.js
@@ -1,19 +1,16 @@
 const path = require('path');
-const yaml = require('yaml-page-objects').default;
 const fs = require('fs');
 const givenSteps = require('../stepDefinitions/commonGivenSteps');
 const whenSteps = require('../stepDefinitions/commonWhenSteps');
 const thenSteps = require('../stepDefinitions/commonThenSteps');
+
 const commonSteps = [].concat(givenSteps, whenSteps, thenSteps);
 require('colors');
-
-// const createPage = require('../../uiTestHelpers/createPage');
-// const createComponent = require('../../uiTestHelpers/createComponent');
 
 const { defineStep } = require(path.join(process.cwd(), 'node_modules/cucumber'));
 const { pomConfig } = require(path.join(process.cwd(), process.env.confFile || 'courgette-conf.js'));
 
-let stepsObj = {};
+const stepsObj = {};
 let currentStep;
 
 const stepsFiles = fs.readdirSync(pomConfig.stepsPath);
@@ -37,15 +34,12 @@ stepsFiles.forEach((stepsFile) => {
     });
 
     Object.keys(stepsObj).forEach((stepRegexStr) => { // loop each Step:
-      defineStep(new RegExp(stepRegexStr), async function() {
+      defineStep(new RegExp(stepRegexStr), async function () {
         const substeps = stepsObj[stepRegexStr];
         console.log(`\nStep: ${stepRegexStr}`);
-        for (var i = 0; i < substeps.length; i++) {
+        for (let i = 0; i < substeps.length; i+=1) {
           const substepCleaned = substeps[i].stepCleaned;
-          const correspondingCommonStep = commonSteps.find((commonStep) => {
-            return commonStep.regex && commonStep.regex.test(substepCleaned);
-          });
-
+          const correspondingCommonStep = commonSteps.find((commonStep) => commonStep.regex && commonStep.regex.test(substepCleaned));
 
           try {
             if (correspondingCommonStep) {
@@ -66,10 +60,9 @@ stepsFiles.forEach((stepsFile) => {
                     const checkIsCalled = () => {
                       if (doneCallbackCalled) {
                         return res();
-                      } else {
-                        setTimeout(checkIsCalled, 100);
                       }
-                    }
+                      setTimeout(checkIsCalled, 100);
+                    };
                     checkIsCalled();
                   });
               }
@@ -80,7 +73,9 @@ stepsFiles.forEach((stepsFile) => {
               }
               console.log(`            ${substeps[i].step} ---> PASSED`.green);
             } else {
-              return Promise.reject(`No step found for:     ${substeps[i].step}`);
+              console.log(`            ${substeps[i].step} ---> FAILED`.red);
+              console.log(`NO STEP FOUND:     ${substeps[i].step}`);
+              return Promise.reject(`NO STEP FOUND:     ${substeps[i].step}`);
             }
           } catch (e) {
             console.log(`            ${substeps[i].step} ---> FAILED`.red);

--- a/uiTestHelpers/hooks/loadSteps.js
+++ b/uiTestHelpers/hooks/loadSteps.js
@@ -34,10 +34,10 @@ stepsFiles.forEach((stepsFile) => {
     });
 
     Object.keys(stepsObj).forEach((stepRegexStr) => { // loop each Step:
-      defineStep(new RegExp(stepRegexStr), async function () {
+      defineStep(new RegExp(stepRegexStr), async function () { // eslint-disable-line
         const substeps = stepsObj[stepRegexStr];
         console.log(`\nStep: ${stepRegexStr}`);
-        for (let i = 0; i < substeps.length; i+=1) {
+        for (let i = 0; i < substeps.length; i += 1) {
           const substepCleaned = substeps[i].stepCleaned;
           const correspondingCommonStep = commonSteps.find((commonStep) => commonStep.regex && commonStep.regex.test(substepCleaned));
 
@@ -56,31 +56,30 @@ stepsFiles.forEach((stepsFile) => {
                 };
                 args.push(doneCallback);
                 callbackPromise = () =>
-                  new Promise((res, rej) => {
+                  new Promise((res) => {
                     const checkIsCalled = () => {
                       if (doneCallbackCalled) {
                         return res();
                       }
-                      setTimeout(checkIsCalled, 100);
+                      return setTimeout(checkIsCalled, 100);
                     };
-                    checkIsCalled();
+                    return checkIsCalled();
                   });
               }
-              await fn.call(...args);
+              await fn.call(...args); // eslint-disable-line no-await-in-loop
               if (callbackPromise) {
-                // console.log('callbackPromise', callbackPromise);
-                await callbackPromise();
+                await callbackPromise(); // eslint-disable-line no-await-in-loop
               }
               console.log(`            ${substeps[i].step} ---> PASSED`.green);
             } else {
               console.log(`            ${substeps[i].step} ---> FAILED`.red);
               console.log(`NO STEP FOUND:     ${substeps[i].step}`);
-              return Promise.reject(`NO STEP FOUND:     ${substeps[i].step}`);
+              return Promise.reject(new Error(`NO STEP FOUND:     ${substeps[i].step}`));
             }
           } catch (e) {
             console.log(`            ${substeps[i].step} ---> FAILED`.red);
             console.error(e);
-            return Promise.reject(e);
+            return Promise.reject(new Error(e));
           }
         }
       });

--- a/uiTestHelpers/hooks/setDimensions.js
+++ b/uiTestHelpers/hooks/setDimensions.js
@@ -1,7 +1,7 @@
 const { Before } = require('cucumber');
 
 Before(async function () {
-  console.log('Set browser width and height');
+  console.log('            Set browser width and height');
   await this.goToPage('login');
   await browser.driver.manage().window().setSize(1280, 1400);
 });

--- a/uiTestHelpers/stepDefinitions/actions/clickElementThatContainsText.js
+++ b/uiTestHelpers/stepDefinitions/actions/clickElementThatContainsText.js
@@ -7,7 +7,7 @@ module.exports = function clickElementThatContainsText(nth, text) {
     xpath = `(${xpath})[${nth.replace(/\D/g, '')}]`;
   }
 
-  console.log('            Getting element by xpath:');
+  console.log('            Getting clickable element (a, input, button) by xpath:');
   console.log('              ', xpath);
   const elToClick = element(by.xpath(xpath));
   return browser.wait(EC.presenceOf(elToClick))

--- a/uiTestHelpers/stepDefinitions/actions/clickElementThatContainsText.js
+++ b/uiTestHelpers/stepDefinitions/actions/clickElementThatContainsText.js
@@ -7,7 +7,8 @@ module.exports = function clickElementThatContainsText(nth, text) {
     xpath = `(${xpath})[${nth.replace(/\D/g, '')}]`;
   }
 
-  console.log('Getting element by xpath: ', xpath);
+  console.log('            Getting element by xpath:');
+  console.log('              ', xpath);
   const elToClick = element(by.xpath(xpath));
   return browser.wait(EC.presenceOf(elToClick))
     .then(() => elToClick.click());

--- a/uiTestHelpers/stepDefinitions/actions/clickElementWithText.js
+++ b/uiTestHelpers/stepDefinitions/actions/clickElementWithText.js
@@ -6,7 +6,8 @@ module.exports = function clickElementWithText(nth, text) {
     // remove nd from 2nd for example
     xpath = `(${xpath})[${nth.replace(/\D/g, '')}]`;
   }
-  console.log('Getting element by xpath: ', xpath);
+  console.log('            Getting element by xpath:');
+  console.log('              ', xpath);
   const elToClick = element(by.xpath(xpath));
   return browser.wait(EC.presenceOf(elToClick))
     .then(() => elToClick.click());

--- a/uiTestHelpers/stepDefinitions/actions/clickElementWithText.js
+++ b/uiTestHelpers/stepDefinitions/actions/clickElementWithText.js
@@ -6,7 +6,7 @@ module.exports = function clickElementWithText(nth, text) {
     // remove nd from 2nd for example
     xpath = `(${xpath})[${nth.replace(/\D/g, '')}]`;
   }
-  console.log('            Getting element by xpath:');
+  console.log('            Getting clickable element (a, input, button) by xpath:');
   console.log('              ', xpath);
   const elToClick = element(by.xpath(xpath));
   return browser.wait(EC.presenceOf(elToClick))

--- a/uiTestHelpers/stepDefinitions/actions/goToURL.js
+++ b/uiTestHelpers/stepDefinitions/actions/goToURL.js
@@ -6,7 +6,7 @@ module.exports = function goToURL(pageUrl) {
   // add protocol and host from pomConfig if pageUrl in the page object is just a pathname
   const fullUrl = `${pageUrl.startsWith('http') ? '' : pomConfig.baseUrl}${pageUrl}`;
 
-  console.log('Getting the full url: ', fullUrl);
+  console.log('            Getting the full url: ', fullUrl);
 
   return browser.get(fullUrl);
 };

--- a/uiTestHelpers/stepDefinitions/actions/goToURL.js
+++ b/uiTestHelpers/stepDefinitions/actions/goToURL.js
@@ -6,7 +6,7 @@ module.exports = function goToURL(pageUrl) {
   // add protocol and host from pomConfig if pageUrl in the page object is just a pathname
   const fullUrl = `${pageUrl.startsWith('http') ? '' : pomConfig.baseUrl}${pageUrl}`;
 
-  console.log('            Getting the full url: ', fullUrl);
+  // console.log('            Getting the full url: ', fullUrl);
 
   return browser.get(fullUrl);
 };

--- a/uiTestHelpers/stepDefinitions/actions/goToURL.js
+++ b/uiTestHelpers/stepDefinitions/actions/goToURL.js
@@ -6,7 +6,7 @@ module.exports = function goToURL(pageUrl) {
   // add protocol and host from pomConfig if pageUrl in the page object is just a pathname
   const fullUrl = `${pageUrl.startsWith('http') ? '' : pomConfig.baseUrl}${pageUrl}`;
 
-  // console.log('            Getting the full url: ', fullUrl);
+  console.log('            Trying to get: ', fullUrl);
 
   return browser.get(fullUrl);
 };

--- a/uiTestHelpers/stepDefinitions/actions/takeScreenshot.js
+++ b/uiTestHelpers/stepDefinitions/actions/takeScreenshot.js
@@ -15,7 +15,7 @@ module.exports = function takeScreenshot(filename, callback) {
     }
     const screenshotFilePath = path.join(screenshotsDir, `${screenshotName}.png`);
     const stream = fs.createWriteStream(screenshotFilePath);
-    console.log('ScreenshotFilePath: ', screenshotFilePath);
+    console.log('            ScreenshotFilePath: ', screenshotFilePath);
     this.attach(`ScreenshotFilePath: ${screenshotFilePath}`);
     stream.write(Buffer.from(png, 'base64'));
     stream.end();

--- a/uiTestHelpers/stepDefinitions/checks/checkUrl.js
+++ b/uiTestHelpers/stepDefinitions/checks/checkUrl.js
@@ -13,7 +13,7 @@ module.exports = function checkUrl(isNot, expectedUrl) {
           resolve();
         } else if (Date.now() > timestamp + waitTimeout) {
           console.log('Current URL doesn’t match that in page object');
-          console.log('Current URL: ', currentUrlNoTrailingSlash);
+          console.log('Current URL:  ', currentUrlNoTrailingSlash);
           console.log('Expected URL: ', expectedUrlNoTrailingSlash);
           const err = `Current URL: ${currentUrlNoTrailingSlash} ... Expected URL: ${expectedUrlNoTrailingSlash}`;
 

--- a/uiTestHelpers/stepDefinitions/checks/setPageObjectThenCheckUrl.js
+++ b/uiTestHelpers/stepDefinitions/checks/setPageObjectThenCheckUrl.js
@@ -22,7 +22,7 @@ module.exports = function setPageObjectThenCheckUrl(pageName) {
           resolve();
         } else if (Date.now() > ((timestamp + waitTimeout) - 100)) {
           console.log('Current URL doesn’t match that in page object');
-          console.log('Current URL: ', currentUrlNoTrailingSlash);
+          console.log('Current URL:  ', currentUrlNoTrailingSlash);
           console.log('Expected URL: ', expectedUrlNoTrailingSlash);
           const err = `Current URL: ${currentUrlNoTrailingSlash} ... Expected URL: ${expectedUrlNoTrailingSlash}`;
           reject(err);

--- a/uiTestHelpers/stepDefinitions/commonGivenSteps.js
+++ b/uiTestHelpers/stepDefinitions/commonGivenSteps.js
@@ -64,7 +64,7 @@ if (!argv.genFiles) {
       .replace(new RegExp(`(${placeholders.join('|')})`, 'g'), matchPattern);
 
     Given(new RegExp(`^${matcher}$`), {}, require(step.path));
-    step.regex = new RegExp(`^${matcher}$`);
+    step.regex = new RegExp(`^${matcher}$`); // eslint-disable-line no-param-reassign
   });
 }
 

--- a/uiTestHelpers/stepDefinitions/commonGivenSteps.js
+++ b/uiTestHelpers/stepDefinitions/commonGivenSteps.js
@@ -64,6 +64,7 @@ if (!argv.genFiles) {
       .replace(new RegExp(`(${placeholders.join('|')})`, 'g'), matchPattern);
 
     Given(new RegExp(`^${matcher}$`), {}, require(step.path));
+    step.regex = new RegExp(`^${matcher}$`);
   });
 }
 

--- a/uiTestHelpers/stepDefinitions/commonThenSteps.js
+++ b/uiTestHelpers/stepDefinitions/commonThenSteps.js
@@ -116,6 +116,7 @@ if (!argv.genFiles) {
       .replace(new RegExp(`(${placeholders.join('|')})`, 'g'), matchPattern);
 
     Then(new RegExp(`^${matcher}$`), {}, require(step.path));
+    step.regex = new RegExp(`^${matcher}$`);
   });
   Then(/^fail step and take screenshot$/, {}, () => Promise.reject(new Error('Failing step and taking screenshot')));
 }

--- a/uiTestHelpers/stepDefinitions/commonThenSteps.js
+++ b/uiTestHelpers/stepDefinitions/commonThenSteps.js
@@ -116,7 +116,7 @@ if (!argv.genFiles) {
       .replace(new RegExp(`(${placeholders.join('|')})`, 'g'), matchPattern);
 
     Then(new RegExp(`^${matcher}$`), {}, require(step.path));
-    step.regex = new RegExp(`^${matcher}$`);
+    step.regex = new RegExp(`^${matcher}$`); // eslint-disable-line no-param-reassign
   });
   Then(/^fail step and take screenshot$/, {}, () => Promise.reject(new Error('Failing step and taking screenshot')));
 }

--- a/uiTestHelpers/stepDefinitions/commonWhenSteps.js
+++ b/uiTestHelpers/stepDefinitions/commonWhenSteps.js
@@ -52,7 +52,7 @@ if (!argv.genFiles) {
       .replace(new RegExp(`(${placeholders.join('|')})`, 'g'), matchPattern);
 
     When(new RegExp(`^${matcher}$`), {}, require(step.path));
-    step.regex = new RegExp(`^${matcher}$`);
+    step.regex = new RegExp(`^${matcher}$`); // eslint-disable-line no-param-reassign
   });
 }
 

--- a/uiTestHelpers/stepDefinitions/commonWhenSteps.js
+++ b/uiTestHelpers/stepDefinitions/commonWhenSteps.js
@@ -52,6 +52,7 @@ if (!argv.genFiles) {
       .replace(new RegExp(`(${placeholders.join('|')})`, 'g'), matchPattern);
 
     When(new RegExp(`^${matcher}$`), {}, require(step.path));
+    step.regex = new RegExp(`^${matcher}$`);
   });
 }
 

--- a/uiTests/features/google.feature
+++ b/uiTests/features/google.feature
@@ -19,3 +19,8 @@ Feature: Test feature
     # Given I am on the 'Google home' page        <--------- or this will work
     When I click 'I’m Feeling Lucky'
     Then I expect the url to contain 'google.com/doodles'
+
+  @google-feeling-lucky-reusable-steps
+  Scenario: Sample using reusable steps
+    Given I am on the 'google-home' page and I click 'I’m Feeling Lucky'
+    Then I expect the url to contain 'google.com/doodles' then take a screenshot

--- a/uiTests/stepDefinitions/reusable.steps
+++ b/uiTests/stepDefinitions/reusable.steps
@@ -1,0 +1,9 @@
+Steps: Some reusable steps
+
+  Step: I am on the 'google-home' page and I click 'I’m Feeling Lucky'
+    Given I am on the page with url '/'
+    When I click the element that contains the text 'de la chance'
+
+  Step: I expect the url to contain 'google.com/doodles' then take a screenshot
+    Then I expect the url to contain 'google.com/doodles'
+    Then take a screenshot


### PR DESCRIPTION
This feature allows you to create your own step definitions using a simpler interface - the Gherkin syntax - rather than JS. It also allows you to create parameters. Like {{THIS_ONE}}. See examples below:

```
Steps: Some reusable steps

  Step: I am on the homepage page and I click the link
    Given I am on the page with url 'http://localhost:3000'
    When I click the element with the text 'Go to other page by react router'

  Step: I do some assertions
    Then I expect the url to be 'http://localhost:3000/other-page'
    And I expect the url to not be 'http://localhost:3000/foo'
    And take a screenshot

  Step: I am on the page with url '{{PAGE}}' and I click '{{LINK}}'
    Given I am on the page with url '{{PAGE}}'
    When I click the element with the text '{{LINK}}'
```

By creating the steps above you can use them in your scenarios e.g.:

```
  @no-po-reusable-steps
  Scenario: Testing reusable steps
    Given I am on the homepage page and I click the link
    Then I do some assertions

  @no-po-reusable-steps-with-params
  Scenario: Testing reusable steps with params
    Given I am on the page with url 'http://localhost:3000' and I click 'Go to other page by react router'
    Then I do some assertions
```