### PR TITLE
adding support for uploading files

### DIFF
--- a/placeholders.js
+++ b/placeholders.js
@@ -9,6 +9,7 @@ const placeholders = [
   'VALUE',
   'KEY',
   'NUMBER',
+  'SELECTOR',
   'LOCATOR',
 ];
 

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -27,6 +27,12 @@ const Home = () => (
     </ul>
 
     <form action="" data-test="form" onSubmit={(e) => { global.location.href = 'http://localhost:3000/other-page'; e.preventDefault(); }}>
+      <p>
+        <label>
+          <input type="file" name="a-file" data-test="a-file" />
+          Upload file
+        </label>
+      </p>
       <p><label>Name <input type="text" name="fullname" data-test="fullname" /></label></p>
       <p><label>Email <input type="text" name="email" data-test="email" defaultValue="hi@hello.com" /></label></p>
       <p><label>Hidden field <input type="text" name="hidden-field" data-test="hidden-field" style={{ display: 'none' }} /></label></p>

--- a/testsToValidateStepDefinitions/features/when.feature
+++ b/testsToValidateStepDefinitions/features/when.feature
@@ -4,6 +4,14 @@ Feature: Testing When steps
   Background: I am on the homepage
     Given I am on the 'Home' page
 
+  @when-upload-file-selector
+  Scenario: When I upload a file
+    When I set the file upload 'testsToValidateStepDefinitions/features/given.feature' to element with selector '[data-test="a-file"]'
+
+  @when-upload-file
+  Scenario: When I upload a file
+    When I set the file upload 'testsToValidateStepDefinitions/features/given.feature' to the 'file upload'
+
   @when-steps-append-value
   Scenario: When I append to a field
     When I append 'hello' to 'email'

--- a/testsToValidateStepDefinitions/pages/home.js
+++ b/testsToValidateStepDefinitions/pages/home.js
@@ -26,6 +26,7 @@ module.exports = (world) => {
     'you ok checkbox': by.css('[data-test="you-ok-checkbox"]'),
     'non-existant element': by.css('[data-test="non-existant"]'),
     'another simple page react link': by.css('[data-test="another-simple-page-react-link"]'),
+    'file upload': by.css('[data-test="a-file"]'),
     'Go to home page by react router link': by.css('[data-test="go-to-home-link"]'), // doesn't actually exist on this page, just using to test that it doesn't exist
   };
 

--- a/uiTestHelpers/createComponent.js
+++ b/uiTestHelpers/createComponent.js
@@ -46,6 +46,12 @@ module.exports = (name, world, elLocators, type = 'component', customMethods = {
       return components[componentName];
     },
 
+    getSelectorFromLocatorKey(locatorKey) {
+      if (locators[locatorKey]) {
+        return locators[locatorKey].value;
+      }
+    },
+
     getElement(locator) {
       locatorErrorCheck(locator);
 

--- a/uiTestHelpers/createComponent.js
+++ b/uiTestHelpers/createComponent.js
@@ -50,6 +50,7 @@ module.exports = (name, world, elLocators, type = 'component', customMethods = {
       if (locators[locatorKey]) {
         return locators[locatorKey].value;
       }
+      return null;
     },
 
     getElement(locator) {

--- a/uiTestHelpers/stepDefinitions/actions/uploadFile.js
+++ b/uiTestHelpers/stepDefinitions/actions/uploadFile.js
@@ -1,4 +1,5 @@
 const path = require('path');
+
 module.exports = function uploadFile(fileToUpload, locatorKey) {
   const currentPage = this.getCurrentPage();
   const cssSelector = currentPage.getSelectorFromLocatorKey(locatorKey);
@@ -7,7 +8,7 @@ module.exports = function uploadFile(fileToUpload, locatorKey) {
     .then((el) => {
       const absolutePath = path.resolve(fileToUpload);
 
-      browser.executeAsyncScript(function(selector, callback) {
+      browser.executeAsyncScript((selector, callback) => {
         document.querySelector(selector).style.display = 'inline';
         callback();
       }, cssSelector);

--- a/uiTestHelpers/stepDefinitions/actions/uploadFile.js
+++ b/uiTestHelpers/stepDefinitions/actions/uploadFile.js
@@ -1,0 +1,17 @@
+const path = require('path');
+module.exports = function uploadFile(fileToUpload, locatorKey) {
+  const currentPage = this.getCurrentPage();
+  const cssSelector = currentPage.getSelectorFromLocatorKey(locatorKey);
+  return currentPage
+    .getElementWhenInDOM(locatorKey)
+    .then((el) => {
+      const absolutePath = path.resolve(fileToUpload);
+
+      browser.executeAsyncScript(function(selector, callback) {
+        document.querySelector(selector).style.display = 'inline';
+        callback();
+      }, cssSelector);
+
+      return el.sendKeys(absolutePath);
+    });
+};

--- a/uiTestHelpers/stepDefinitions/actions/uploadFileSelector.js
+++ b/uiTestHelpers/stepDefinitions/actions/uploadFileSelector.js
@@ -1,0 +1,16 @@
+const path = require('path');
+const EC = protractor.ExpectedConditions;
+module.exports = function uploadFileSelector(fileToUpload, cssSelector) {
+  const elemelon = element(by.css(cssSelector));
+  return browser.wait(EC.visibilityOf(elemelon))
+    .then(() => {
+      const absolutePath = path.resolve(fileToUpload);
+
+      browser.executeAsyncScript(function(selector, callback) {
+        document.querySelector(selector).style.display = 'inline';
+        callback();
+      }, cssSelector);
+
+      return elemelon.sendKeys(absolutePath);
+    });
+};

--- a/uiTestHelpers/stepDefinitions/actions/uploadFileSelector.js
+++ b/uiTestHelpers/stepDefinitions/actions/uploadFileSelector.js
@@ -1,4 +1,5 @@
 const path = require('path');
+
 const EC = protractor.ExpectedConditions;
 module.exports = function uploadFileSelector(fileToUpload, cssSelector) {
   const elemelon = element(by.css(cssSelector));
@@ -6,7 +7,7 @@ module.exports = function uploadFileSelector(fileToUpload, cssSelector) {
     .then(() => {
       const absolutePath = path.resolve(fileToUpload);
 
-      browser.executeAsyncScript(function(selector, callback) {
+      browser.executeAsyncScript((selector, callback) => {
         document.querySelector(selector).style.display = 'inline';
         callback();
       }, cssSelector);

--- a/uiTestHelpers/stepDefinitions/commonWhenSteps.js
+++ b/uiTestHelpers/stepDefinitions/commonWhenSteps.js
@@ -23,7 +23,7 @@ const steps = [
   },
 
   {
-    matcher: "I set the file upload 'VALUE' to(?: the)? 'LOCATOR'", path: './actions/uploadFile', code: 'uploadfile'
+    matcher: "I set the file upload 'VALUE' to(?: the)? 'LOCATOR'", path: './actions/uploadFile', code: 'uploadfile',
   },
   { matcher: "I click(?: the)? 'LOCATOR'", path: './actions/clickElement', code: 'click' },
   {

--- a/uiTestHelpers/stepDefinitions/commonWhenSteps.js
+++ b/uiTestHelpers/stepDefinitions/commonWhenSteps.js
@@ -6,6 +6,9 @@ const placeholders = require('../../placeholders'); // eslint-disable-line
 
 const steps = [
   {
+    matcher: "I set the file upload 'VALUE' to(?: the)? element with selector 'SELECTOR'", path: './actions/uploadFileSelector', code: 'uploadfileselector', pageObjectNotRequired: true,
+  },
+  {
     matcher: "I click(?: the)?(?: 'NTH')? element with the text 'VALUE'", path: './actions/clickElementWithText', code: 'clickelwithtext', pageObjectNotRequired: true,
   },
   {
@@ -19,6 +22,9 @@ const steps = [
     pageObjectNotRequired: true,
   },
 
+  {
+    matcher: "I set the file upload 'VALUE' to(?: the)? 'LOCATOR'", path: './actions/uploadFile', code: 'uploadfile'
+  },
   { matcher: "I click(?: the)? 'LOCATOR'", path: './actions/clickElement', code: 'click' },
   {
     matcher: "I click(?: the)? 'LOCATOR' inside(?: the)? 'LOCATOR'", path: './actions/clickElementInsideElement', code: 'clickelinsideel', notes: 'This currently only works with XPaths',


### PR DESCRIPTION
Adding two new step definitions:

```
When I set the file upload 'uiTests/features/file.txt' to the 'LOCATOR'
```
...for use with page objects and:

```
When I set the file upload 'uiTests/features/file.txt' to the element with selector 'SELECTOR'
```
...or use without page objects.