### PR TITLE
enable colours in cucumber opts for cli formatter

### DIFF
--- a/courgette-conf.js
+++ b/courgette-conf.js
@@ -77,6 +77,7 @@ const protractorConfig = {
       'cucumberFormatter.js',
       `json:./${outputPath}/report.json`,
     ].concat(process.env.showStepDefinitionUsage ? 'node_modules/cucumber/lib/formatter/usage_formatter.js' : []),
+    'format-options': '{"colorsEnabled": true}',
     'profile': false,
     'no-source': true,
   },

--- a/sample-courgette-conf-for-test.js
+++ b/sample-courgette-conf-for-test.js
@@ -76,6 +76,7 @@ const protractorConfig = {
       'cucumberFormatter.js',
       `json:./${outputPath}/report.json`,
     ].concat(process.env.showStepDefinitionUsage ? 'node_modules/cucumber/lib/formatter/usage_formatter.js' : []),
+    'format-options': '{"colorsEnabled": true}',
     'profile': false,
     'no-source': true,
   },

--- a/sample-courgette-conf.js
+++ b/sample-courgette-conf.js
@@ -80,6 +80,7 @@ const protractorConfig = {
       'node_modules/courgette/cucumberFormatter.js',
       `json:./${outputPath}/report.json`,
     ].concat(process.env.showStepDefinitionUsage ? 'node_modules/cucumber/lib/formatter/usage_formatter.js' : []),
+    'format-options': '{"colorsEnabled": true}',
     'profile': false,
     'no-source': true,
   },


### PR DESCRIPTION
They were turned off by default in the latest cucumber package. We want colours though so explicitly setting them to true