### PR TITLE
Remove taken screenshot from report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.11.0
+* forceSuccess flag added to pomConfig to force success exitCode even if the total number of specs matches the success count
 ## 3.8.2
 * steps timeout - crude solution - number of steps x timeout set. This means that if you have a long step and the first times out, you may be waiting a while
 ## 3.8.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "courgette",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "courgette",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "Courgette - Bootstrap your cucumber tests with cucumber, protractor and a structured way of creating page objects and component objects",
   "main": "index.js",
   "scripts": {

--- a/uiTestHelpers/stepDefinitions/actions/takeScreenshot.js
+++ b/uiTestHelpers/stepDefinitions/actions/takeScreenshot.js
@@ -4,8 +4,6 @@ const path = require('path');
 const { pomConfig } = require(path.join(process.cwd(), process.env.confFile || 'courgette-conf.js'));
 
 module.exports = function takeScreenshot(filename, callback) {
-  let bufferedImage;
-
   browser.takeScreenshot().then((png) => {
     const screenshotName = filename || `${this.scenarioName.replace(/ /g, '-')}-${Date.now()}`;
     const screenshotStepPath = (pomConfig.screenshotStepPath || 'stepDefinitionScreenshots');
@@ -16,9 +14,6 @@ module.exports = function takeScreenshot(filename, callback) {
     this.attach(`ScreenshotFilePath: ${screenshotFilePath}`);
     stream.write(Buffer.from(png, 'base64'));
     stream.end();
-    bufferedImage = Buffer.from(png.replace(/^data:image\/(png|gif|jpeg);base64,/, ''), 'base64');
-    this.attach('take a screenshot step - screenshot attached.');
-    this.attach(bufferedImage, 'image/png');
     callback();
   });
 };


### PR DESCRIPTION
Error screenshots will still appear in the HTML report, but step definition taken screenshots will not